### PR TITLE
fresh rultor

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,23 +1,20 @@
-docker:
-  image: yegor256/rultor-image:1.3
-install: |
-  sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
 architect:
-  - vzurauskas
-readers:
-  - "urn:github:18754033"
+  - h1alexbel
+docker:
+  image: l3r8y/rultor-image:1.0.3
 assets:
-  settings.xml: vzurauskas/secrets#nereides/settings.xml
-  pubring.gpg: vzurauskas/secrets#pubring.gpg
-  secring.gpg: vzurauskas/secrets#secring.gpg
+  settings.xml: eo-cqrs/eo-cqrs-secrets#assets/settings.xml
+  secring.gpg: eo-cqrs/eo-cqrs-secrets#assets/secring.gpg
+  pubring.gpg: eo-cqrs/eo-cqrs-secrets#assets/pubring.gpg
 merge:
-  script: |
-    mvn clean install -Pwall --errors
+  script:
+    - "mvn clean install --errors --batch-mode"
 release:
-  # https://github.com/vzurauskas/nereides-jackson/issues/29
-  # mvn clean deploy nullfree:nullfree -Pwall -Pnereides -Prelease --errors --settings /home/r/settings.xml
+  pre: false
+  sensetive:
+    - settings.xml
   script: |-
-    [[ "${tag}" =~ ^[0-9]+(\.[0-9]+)*$ ]] || exit -1
+    [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}"
     git commit -am "${tag}"
-    mvn clean deploy -Pwall -Pnereides -Prelease --errors --settings /home/r/settings.xml
+    mvn clean deploy -Prelease --errors --settings ../settings.xml


### PR DESCRIPTION
closes #7 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `.rultor.yml` file, changing the `architect` and `readers` fields and updating the `docker` image. It also changes the location of the `settings.xml`, `pubring.gpg`, and `secring.gpg` files and updates the `script` field in the `merge` and `release` sections.

### Detailed summary
- Changes `architect` field to `h1alexbel`
- Changes `readers` field to `urn:github:18754033`
- Updates `docker` image to `l3r8y/rultor-image:1.0.3`
- Changes location of `settings.xml`, `pubring.gpg`, and `secring.gpg` files
- Updates `script` field in `merge` section to use `--batch-mode` flag
- Removes `pre` field and adds `sensitive` field in `release` section
- Updates `script` field in `release` section to use `../settings.xml` file location

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->