### PR TITLE
missing

### DIFF
--- a/src/main/java/io/github/eocqrs/eokson/Missing.java
+++ b/src/main/java/io/github/eocqrs/eokson/Missing.java
@@ -22,7 +22,6 @@
 
 package io.github.eocqrs.eokson;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 /**
@@ -30,7 +29,7 @@ import java.io.InputStream;
  * It is equivalent to
  * {@code new Json.Of(new byte[0])}.
  */
-public final class MissingJson implements Json {
+public final class Missing implements Json {
 
   /**
    * Missing bytes.
@@ -39,6 +38,6 @@ public final class MissingJson implements Json {
 
   @Override
   public InputStream bytes() {
-    return new ByteArrayInputStream(MISSING);
+    return new Json.Of(MISSING).bytes();
   }
 }

--- a/src/test/java/io/github/eocqrs/eokson/MissingTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/MissingTest.java
@@ -25,15 +25,14 @@ package io.github.eocqrs.eokson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 
-import io.github.eocqrs.eokson.MissingJson;
 import org.junit.jupiter.api.Test;
 
-final class MissingJsonTest {
+final class MissingTest {
     @Test
     void creates() throws IOException {
         assertEquals(
             0,
-            new MissingJson().bytes().available()
+            new Missing().bytes().available()
         );
     }
 }

--- a/src/test/java/io/github/eocqrs/eokson/SmartJsonTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/SmartJsonTest.java
@@ -175,7 +175,7 @@ final class SmartJsonTest {
 
   @Test
   void knowsIfMissing() {
-    assertTrue(new SmartJson(new MissingJson()).isMissing());
+    assertTrue(new SmartJson(new Missing()).isMissing());
   }
 
   @Test


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR renames `MissingJson` to `Missing` and updates all references to it. It also simplifies `Missing` by removing `ByteArrayInputStream` and using `Json.Of` instead. 

### Detailed summary
- Renamed `MissingJson` to `Missing`
- Updated all references to `MissingJson` to `Missing`
- Removed `ByteArrayInputStream`
- Used `Json.Of` instead of `ByteArrayInputStream` in `Missing`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->