### PR TITLE
Json.Of migration

### DIFF
--- a/src/main/java/io/github/eocqrs/eokson/Empty.java
+++ b/src/main/java/io/github/eocqrs/eokson/Empty.java
@@ -31,7 +31,7 @@ public final class Empty implements Json {
 
   @Override
   public InputStream bytes() {
-    return new Json.Of("{}").bytes();
+    return new JsonOf("{}").bytes();
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/eokson/Json.java
+++ b/src/main/java/io/github/eocqrs/eokson/Json.java
@@ -22,22 +22,12 @@
 
 package io.github.eocqrs.eokson;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.function.Supplier;
 
 /**
  * JSON document. This is the type to be implemented by all objects which
  * represent JSONs.
- * In addition to writing custom {@code Json} objects, various data types
- * can be represented as {@code Json} by instantiating a {@link Json.Of} object.
+ * In addition to writing custom {@code Json} objects.
  */
 public interface Json {
 
@@ -47,129 +37,4 @@ public interface Json {
    * @return {@link InputStream} with bytes representing this {@code Json}.
    */
   InputStream bytes();
-
-  /**
-   * {@link Json}, constructed from JSON represented by other data types
-   * such as byte array, {@code String}, {@code InputStream} and so forth.
-   * E.g.
-   * <pre>
-   * {@code
-   * String jsonAsString = ...;
-   * Json json = new Json.Of(jsonAsString);
-   * }
-   * </pre>
-   */
-  final class Of implements Json {
-
-    /**
-     * Object Mapper.
-     */
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    /**
-     * Origin.
-     */
-    private final Json origin;
-
-    /**
-     * Ctor.
-     *
-     * @param node JSON represented by {@link JsonNode} from
-     *             'jackson-databind' library.
-     */
-    public Of(final JsonNode node) {
-      this(() -> node);
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param node JSON represented by {@link JsonNode} from
-     *             'jackson-databind' library.
-     */
-    public Of(final Supplier<JsonNode> node) {
-      this(
-        flattened(
-          () -> {
-            try {
-              return MAPPER.writeValueAsBytes(node.get());
-            } catch (final JsonProcessingException e) {
-              throw new UncheckedIOException(e);
-            }
-          }
-        )
-      );
-    }
-
-    private static <T> T flattened(final Supplier<T> scalar) {
-      return scalar.get();
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param string JSON represented by a {@link String}.
-     */
-    public Of(final String string) {
-      this(string.getBytes());
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param bytes JSON represented by an array of bytes.
-     */
-    public Of(final byte[] bytes) {
-      this(
-        new AutoResetInputStream(
-          new ByteArrayInputStream(bytes)
-        )
-      );
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param stream JSON represented by the bytes in an
-     *               {@link InputStream}.
-     */
-    public Of(final InputStream stream) {
-      this.origin = () -> stream;
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param path Path to a JSON in a file.
-     */
-    public Of(final Path path) {
-      this(
-        new Cached<>(
-          () -> new Unchecked<>(
-            () -> new AutoResetInputStream(
-              new ByteArrayInputStream(Files.readAllBytes(path))
-            )
-          ).value()
-        )
-      );
-    }
-
-    private Of(final Cached<InputStream> cached) {
-      this(cached::value);
-    }
-
-    private Of(final Json json) {
-      this.origin = json;
-    }
-
-    @Override
-    public InputStream bytes() {
-      return this.origin.bytes();
-    }
-
-    @Override
-    public String toString() {
-      return new String(new ByteArray(this).value());
-    }
-  }
 }

--- a/src/main/java/io/github/eocqrs/eokson/JsonOf.java
+++ b/src/main/java/io/github/eocqrs/eokson/JsonOf.java
@@ -1,3 +1,25 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.github.eocqrs.eokson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/io/github/eocqrs/eokson/JsonOf.java
+++ b/src/main/java/io/github/eocqrs/eokson/JsonOf.java
@@ -81,17 +81,13 @@ public final class JsonOf implements Json {
     );
   }
 
-  private static <T> T flattened(final Supplier<T> scalar) {
-    return scalar.get();
-  }
-
   /**
    * Ctor.
    *
-   * @param string JSON represented by a {@link String}.
+   * @param str JSON represented by a {@link String}.
    */
-  public JsonOf(final String string) {
-    this(string.getBytes());
+  public JsonOf(final String str) {
+    this(str.getBytes());
   }
 
   /**
@@ -134,12 +130,26 @@ public final class JsonOf implements Json {
     );
   }
 
-  private JsonOf(final Cached<InputStream> cached) {
+  /**
+   * Ctor.
+   *
+   * @param cached Cached
+   */
+  public JsonOf(final Cached<InputStream> cached) {
     this(cached::value);
   }
 
-  private JsonOf(final Json json) {
+  /**
+   * Ctor.
+   *
+   * @param json JSON
+   */
+  public JsonOf(final Json json) {
     this.origin = json;
+  }
+
+  private static <T> T flattened(final Supplier<T> scalar) {
+    return scalar.get();
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/eokson/JsonOf.java
+++ b/src/main/java/io/github/eocqrs/eokson/JsonOf.java
@@ -1,0 +1,132 @@
+package io.github.eocqrs.eokson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+/**
+ * JSON Decorator.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.1.1
+ */
+public final class JsonOf implements Json {
+
+  /**
+   * Object Mapper.
+   */
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * Origin.
+   */
+  private final Json origin;
+
+  /**
+   * Ctor.
+   *
+   * @param node JSON represented by {@link JsonNode} from
+   *             'jackson-databind' library.
+   */
+  public JsonOf(final JsonNode node) {
+    this(() -> node);
+  }
+
+  /**
+   * Ctor.
+   *
+   * @param node JSON represented by {@link JsonNode} from
+   *             'jackson-databind' library.
+   */
+  public JsonOf(final Supplier<JsonNode> node) {
+    this(
+      flattened(
+        () -> {
+          try {
+            return MAPPER.writeValueAsBytes(node.get());
+          } catch (final JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+          }
+        }
+      )
+    );
+  }
+
+  private static <T> T flattened(final Supplier<T> scalar) {
+    return scalar.get();
+  }
+
+  /**
+   * Ctor.
+   *
+   * @param string JSON represented by a {@link String}.
+   */
+  public JsonOf(final String string) {
+    this(string.getBytes());
+  }
+
+  /**
+   * Ctor.
+   *
+   * @param bytes JSON represented by an array of bytes.
+   */
+  public JsonOf(final byte[] bytes) {
+    this(
+      new AutoResetInputStream(
+        new ByteArrayInputStream(bytes)
+      )
+    );
+  }
+
+  /**
+   * Ctor.
+   *
+   * @param stream JSON represented by the bytes in an
+   *               {@link InputStream}.
+   */
+  public JsonOf(final InputStream stream) {
+    this.origin = () -> stream;
+  }
+
+  /**
+   * Ctor.
+   *
+   * @param path Path to a JSON in a file.
+   */
+  public JsonOf(final Path path) {
+    this(
+      new Cached<>(
+        () -> new Unchecked<>(
+          () -> new AutoResetInputStream(
+            new ByteArrayInputStream(Files.readAllBytes(path))
+          )
+        ).value()
+      )
+    );
+  }
+
+  private JsonOf(final Cached<InputStream> cached) {
+    this(cached::value);
+  }
+
+  private JsonOf(final Json json) {
+    this.origin = json;
+  }
+
+  @Override
+  public InputStream bytes() {
+    return this.origin.bytes();
+  }
+
+  @Override
+  public String toString() {
+    return new String(new ByteArray(this).value());
+  }
+}

--- a/src/main/java/io/github/eocqrs/eokson/JsonOf.java
+++ b/src/main/java/io/github/eocqrs/eokson/JsonOf.java
@@ -54,8 +54,7 @@ public final class JsonOf implements Json {
   /**
    * Ctor.
    *
-   * @param node JSON represented by {@link JsonNode} from
-   *             'jackson-databind' library.
+   * @param node JSON represented by {@link JsonNode}
    */
   public JsonOf(final JsonNode node) {
     this(() -> node);
@@ -64,8 +63,7 @@ public final class JsonOf implements Json {
   /**
    * Ctor.
    *
-   * @param node JSON represented by {@link JsonNode} from
-   *             'jackson-databind' library.
+   * @param node JSON represented by {@link JsonNode}
    */
   public JsonOf(final Supplier<JsonNode> node) {
     this(
@@ -93,7 +91,7 @@ public final class JsonOf implements Json {
   /**
    * Ctor.
    *
-   * @param bytes JSON represented by an array of bytes.
+   * @param bytes JSON represented by an array of bytes
    */
   public JsonOf(final byte[] bytes) {
     this(
@@ -107,7 +105,7 @@ public final class JsonOf implements Json {
    * Ctor.
    *
    * @param stream JSON represented by the bytes in an
-   *               {@link InputStream}.
+   *               {@link InputStream}
    */
   public JsonOf(final InputStream stream) {
     this.origin = () -> stream;
@@ -116,7 +114,7 @@ public final class JsonOf implements Json {
   /**
    * Ctor.
    *
-   * @param path Path to a JSON in a file.
+   * @param path Path to a JSON in a file
    */
   public JsonOf(final Path path) {
     this(

--- a/src/main/java/io/github/eocqrs/eokson/Missing.java
+++ b/src/main/java/io/github/eocqrs/eokson/Missing.java
@@ -38,6 +38,6 @@ public final class Missing implements Json {
 
   @Override
   public InputStream bytes() {
-    return new Json.Of(MISSING).bytes();
+    return new JsonOf(MISSING).bytes();
   }
 }

--- a/src/main/java/io/github/eocqrs/eokson/MutableJson.java
+++ b/src/main/java/io/github/eocqrs/eokson/MutableJson.java
@@ -143,7 +143,7 @@ public final class MutableJson implements Json {
 
   @Override
   public InputStream bytes() {
-    return new Json.Of(this.base).bytes();
+    return new JsonOf(this.base).bytes();
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/eokson/SmartJson.java
+++ b/src/main/java/io/github/eocqrs/eokson/SmartJson.java
@@ -266,7 +266,7 @@ public final class SmartJson implements Json {
    */
   public SmartJson at(final String path) {
     return new SmartJson(
-      new Json.Of(this.jackson.value().at(path))
+      new JsonOf(this.jackson.value().at(path))
     );
   }
 

--- a/src/test/java/io/github/eocqrs/eokson/EmptyTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/EmptyTest.java
@@ -32,7 +32,7 @@ final class EmptyTest {
   void readsEmptyJsonInRightFormat() {
     MatcherAssert.assertThat(
       "JSON in right format",
-      new Json.Of("{}").toString(),
+      new JsonOf("{}").toString(),
       Matchers.equalTo(
         new Empty().toString()
       )

--- a/src/test/java/io/github/eocqrs/eokson/JsonEnvelopeTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/JsonEnvelopeTest.java
@@ -34,7 +34,7 @@ final class JsonEnvelopeTest {
     Assertions.assertDoesNotThrow(
       () ->
         new JsonEnvelopeTest.TestJsonEnvelope(
-          new Json.Of("{}")
+          new JsonOf("{}")
         ).bytes()
     );
   }
@@ -44,7 +44,7 @@ final class JsonEnvelopeTest {
     MatcherAssert.assertThat(
       "JSON bytes is not NULL",
       new JsonEnvelopeTest.TestJsonEnvelope(
-        new Json.Of("{}")
+        new JsonOf("{}")
       ).bytes(),
       Matchers.notNullValue()
     );
@@ -55,10 +55,10 @@ final class JsonEnvelopeTest {
     final String value = "{\"number\": \"12\"}";
     MatcherAssert.assertThat(
       "JSON in right format",
-      new Json.Of(value).toString(),
+      new JsonOf(value).toString(),
       Matchers.equalTo(
         new JsonEnvelopeTest.TestJsonEnvelope(
-          new Json.Of(
+          new JsonOf(
             value
           )
         ).toString()

--- a/src/test/java/io/github/eocqrs/eokson/JsonOfTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/JsonOfTest.java
@@ -52,7 +52,7 @@ final class JsonOfTest {
     );
     assertArrayEquals(
       bytes,
-      new ByteArray(new Json.Of(bytes)).value()
+      new ByteArray(new JsonOf(bytes)).value()
     );
   }
 
@@ -61,7 +61,7 @@ final class JsonOfTest {
     String string = "{\"number\": 12}";
     assertArrayEquals(
       string.getBytes(),
-      new ByteArray(new Json.Of(string)).value()
+      new ByteArray(new JsonOf(string)).value()
     );
   }
 
@@ -71,7 +71,7 @@ final class JsonOfTest {
     assertArrayEquals(
       bytes,
       new ByteArray(
-        new Json.Of(
+        new JsonOf(
           new ByteArrayInputStream(bytes)
         )
       ).value()
@@ -85,7 +85,7 @@ final class JsonOfTest {
       .put("field2", "value2");
     assertArrayEquals(
       MAPPER.writeValueAsBytes(node),
-      new ByteArray(new Json.Of(node)).value()
+      new ByteArray(new JsonOf(node)).value()
     );
   }
 
@@ -96,7 +96,7 @@ final class JsonOfTest {
     );
     assertArrayEquals(
       Files.readAllBytes(path),
-      new ByteArray(new Json.Of(path)).value()
+      new ByteArray(new JsonOf(path)).value()
     );
   }
 
@@ -105,7 +105,7 @@ final class JsonOfTest {
     String string = "[{\"name\":\"Jason\"},{\"name\":\"Thetis\"}]";
     assertArrayEquals(
       string.getBytes(),
-      new ByteArray(new Json.Of(string)).value()
+      new ByteArray(new JsonOf(string)).value()
     );
   }
 
@@ -113,14 +113,14 @@ final class JsonOfTest {
   void toStringWorksEvenIfMalformed() {
     assertEquals(
       "malformed",
-      new Json.Of("malformed").toString()
+      new JsonOf("malformed").toString()
     );
   }
 
   @Test
   void canReadTwice() {
     String string = "{\"number\": 12}";
-    Json json = new Json.Of(string);
+    Json json = new JsonOf(string);
     assertArrayEquals(string.getBytes(), new ByteArray(json).value());
     assertArrayEquals(string.getBytes(), new ByteArray(json).value());
   }
@@ -132,7 +132,7 @@ final class JsonOfTest {
     try (PrintStream ps = new PrintStream(file)) {
       ps.print(string);
     }
-    Json json = new Json.Of(file.toPath());
+    Json json = new JsonOf(file.toPath());
     assertArrayEquals(string.getBytes(), new ByteArray(json).value());
     file.delete();
     assertArrayEquals(string.getBytes(), new ByteArray(json).value());

--- a/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
@@ -77,7 +77,7 @@ final class MutableJsonTest {
     MatcherAssert.assertThat(
       "JSON from file in right format",
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           Paths.get(
             MutableJsonTest.class.getClassLoader().getResource(
               "deep-noarray.json"

--- a/src/test/java/io/github/eocqrs/eokson/SmartJsonTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/SmartJsonTest.java
@@ -55,13 +55,13 @@ final class SmartJsonTest {
 
   @Test
   void givesByteStream() {
-    byte[] bytes = "{\"field1\":\"value1\",\"field2\":\"value2\"}"
+    final byte[] bytes = "{\"field1\":\"value1\",\"field2\":\"value2\"}"
       .getBytes();
     assertArrayEquals(
       bytes,
       new ByteArray(
         new SmartJson(
-          new Json.Of(bytes)
+          new JsonOf(bytes)
         )
       ).value()
     );
@@ -73,7 +73,7 @@ final class SmartJsonTest {
       "{\"field1\":\"value1\","
         + "\"field2\":\"value2\"}",
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", "value2")
@@ -90,7 +90,7 @@ final class SmartJsonTest {
         + "  \"field2\" : \"value2\"" + System.lineSeparator()
         + '}',
       new SmartJson(
-        new Json.Of(
+         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", "value2")
@@ -108,19 +108,19 @@ final class SmartJsonTest {
     );
     assertArrayEquals(
       bytes,
-      new SmartJson(new Json.Of(bytes)).byteArray()
+      new SmartJson(new JsonOf(bytes)).byteArray()
     );
   }
 
   @Test
   void convertsToObjectNode() {
-    ObjectNode node = MAPPER.createObjectNode()
+    final ObjectNode node = MAPPER.createObjectNode()
       .put("field1", "value1")
       .put("field2", "value2");
     assertEquals(
       node,
       new SmartJson(
-        new Json.Of(node)
+        new JsonOf(node)
       ).objectNode()
     );
   }
@@ -130,7 +130,7 @@ final class SmartJsonTest {
     assertEquals(
       "red",
       new SmartJson(
-        new Json.Of(deep)
+        new JsonOf(this.deep)
       ).at("/ocean/rock1/nereid2").leaf("hair")
     );
   }
@@ -139,7 +139,7 @@ final class SmartJsonTest {
   void handlesNonExistentPaths() {
     assertTrue(
       new SmartJson(
-        new Json.Of(deep)
+        new JsonOf(this.deep)
       ).at("/ocean/nothing").isMissing()
     );
   }
@@ -149,7 +149,7 @@ final class SmartJsonTest {
     assertEquals(
       "Jason",
       new SmartJson(
-        new Json.Of(deep)
+        new JsonOf(this.deep)
       ).at("/ocean/rock1/nereid1/associates/0").leaf("name")
     );
   }
@@ -159,7 +159,7 @@ final class SmartJsonTest {
     MatcherAssert.assertThat(
       "JSON in right format",
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           this.deep
         )
       ).at("/ocean/rock1/nereid1/associates/0").textual(),
@@ -173,11 +173,11 @@ final class SmartJsonTest {
   @Disabled
   @Test
   void leafsArrays() {
-    String array = "[{\"name\":\"Jason\"},{\"name\":\"Thetis\"}]";
+    final String array = "[{\"name\":\"Jason\"},{\"name\":\"Thetis\"}]";
     assertEquals(
       "Jason",
       new SmartJson(
-        new Json.Of(deep)
+        new JsonOf(this.deep)
       ).at("/ocean/rock1/nereid1/associates").at("/0").leaf("name")
     );
   }
@@ -189,21 +189,21 @@ final class SmartJsonTest {
 
   @Test
   void knowsIfNotMissing() {
-    assertFalse(new SmartJson(new Json.Of("{}")).isMissing());
+    assertFalse(new SmartJson(new JsonOf("{}")).isMissing());
   }
 
   @Test
   void stringifiesOnMailFormed() {
     assertEquals(
       "malformed",
-      new SmartJson(new Json.Of("malformed")).toString()
+      new SmartJson(new JsonOf("malformed")).toString()
     );
   }
 
   @Test
   void readsTwice() {
-    SmartJson json = new SmartJson(
-      new Json.Of("{\"field1\":\"value1\",\"field2\":\"value2\"}")
+    final SmartJson json = new SmartJson(
+      new JsonOf("{\"field1\":\"value1\",\"field2\":\"value2\"}")
     );
     assertEquals("value1", json.leaf("field1"));
     assertEquals("value1", json.leaf("field1"));
@@ -214,7 +214,7 @@ final class SmartJsonTest {
     assertEquals(
       "value2",
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", "value2")
@@ -228,7 +228,7 @@ final class SmartJsonTest {
     assertEquals(
       "value2",
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", "value2")
@@ -241,7 +241,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentLeaf() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeaf("nonexistent").isPresent()
@@ -254,7 +254,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leaf("nonexistent")
@@ -266,7 +266,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalIfLeafIsNotString() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("intField", 5)
@@ -281,7 +281,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
               .put("field1", "value1")
               .put("intField", 5)
@@ -295,7 +295,7 @@ final class SmartJsonTest {
   void emptyFieldName() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("intField", 5)
@@ -309,7 +309,7 @@ final class SmartJsonTest {
     assertEquals(
       "innerValue",
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -327,7 +327,7 @@ final class SmartJsonTest {
     assertEquals(
       "innerValue",
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -344,7 +344,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentLeafInPath() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeaf("/nonexistent/path").isPresent()
@@ -357,7 +357,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leaf("/nonexistent/path")
@@ -369,7 +369,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalIfLeafInPathIsNotString() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -388,7 +388,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
               .put("field1", "value1")
               .<ObjectNode>set(
@@ -407,7 +407,7 @@ final class SmartJsonTest {
     assertEquals(
       14,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", 14)
@@ -421,7 +421,7 @@ final class SmartJsonTest {
     assertEquals(
       14,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", 14)
@@ -434,7 +434,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentIntLeaf() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeafAsInt("nonexistent").isPresent()
@@ -447,7 +447,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leafAsInt("nonexistent")
@@ -460,7 +460,7 @@ final class SmartJsonTest {
     assertEquals(
       0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("intField", 5)
@@ -474,7 +474,7 @@ final class SmartJsonTest {
     assertEquals(
       0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("intField", 5)
@@ -488,7 +488,7 @@ final class SmartJsonTest {
     assertEquals(
       5,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("doubleField", 5.9)
@@ -502,7 +502,7 @@ final class SmartJsonTest {
     assertEquals(
       5,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("doubleField", 5.9)
@@ -516,7 +516,7 @@ final class SmartJsonTest {
     assertEquals(
       999,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -534,7 +534,7 @@ final class SmartJsonTest {
     assertEquals(
       12,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -551,7 +551,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentLeafIntInPath() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeafAsInt("/nonexistent/path").isPresent()
@@ -564,7 +564,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leafAsInt("/nonexistent/path")
@@ -577,7 +577,7 @@ final class SmartJsonTest {
     assertEquals(
       0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -595,7 +595,7 @@ final class SmartJsonTest {
     assertEquals(
       0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -613,7 +613,7 @@ final class SmartJsonTest {
     assertEquals(
       5,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -631,7 +631,7 @@ final class SmartJsonTest {
     assertEquals(
       14.9,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", 14.9)
             .put("field2", "value2")
@@ -645,7 +645,7 @@ final class SmartJsonTest {
     assertEquals(
       14.9,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", 14.9)
             .put("field2", "value2")
@@ -658,7 +658,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentDoubleLeaf() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeafAsDouble("nonexistent").isPresent()
@@ -671,7 +671,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leafAsDouble("nonexistent")
@@ -684,7 +684,7 @@ final class SmartJsonTest {
     assertEquals(
       0.0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("doubleField", 5.9)
@@ -698,7 +698,7 @@ final class SmartJsonTest {
     assertEquals(
       0.0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("doubleField", 5.9)
@@ -712,7 +712,7 @@ final class SmartJsonTest {
     assertEquals(
       5.0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("intField", 5)
@@ -726,7 +726,7 @@ final class SmartJsonTest {
     assertEquals(
       5.0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("intField", 5)
@@ -740,7 +740,7 @@ final class SmartJsonTest {
     assertEquals(
       999.17,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -758,7 +758,7 @@ final class SmartJsonTest {
     assertEquals(
       12.45,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -775,7 +775,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentLeafDoubleInPath() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeafAsDouble("/nonexistent/path").isPresent()
@@ -788,7 +788,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leafAsDouble("/nonexistent/path")
@@ -801,7 +801,7 @@ final class SmartJsonTest {
     assertEquals(
       0.0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -819,7 +819,7 @@ final class SmartJsonTest {
     assertEquals(
       0.0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -837,7 +837,7 @@ final class SmartJsonTest {
     assertEquals(
       5.0,
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -854,7 +854,7 @@ final class SmartJsonTest {
   void findsOptLeafAsBool() {
     assertTrue(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", true)
@@ -867,7 +867,7 @@ final class SmartJsonTest {
   void findsLeafAsBool() {
     assertTrue(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .put("field2", true)
@@ -880,7 +880,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentBooleanLeaf() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeafAsBool("nonexistent").isPresent()
@@ -893,7 +893,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leafAsBool("nonexistent")
@@ -905,7 +905,7 @@ final class SmartJsonTest {
   void returnsFalseIfOptLeafIsNotBool() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("boolField", true)
@@ -918,7 +918,7 @@ final class SmartJsonTest {
   void returnsFalseIfLeafIsNotBool() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
             .put("boolField", true)
@@ -931,7 +931,7 @@ final class SmartJsonTest {
   void findsOptBoolLeafInPath() {
     assertTrue(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -948,7 +948,7 @@ final class SmartJsonTest {
   void findsLeafBoolInPath() {
     assertTrue(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -965,7 +965,7 @@ final class SmartJsonTest {
   void returnsEmptyOptionalForNonexistentLeafBoolInPath() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
         )
       ).optLeafAsBool("/nonexistent/path").isPresent()
@@ -978,7 +978,7 @@ final class SmartJsonTest {
       assertThrows(
         IllegalArgumentException.class,
         () -> new SmartJson(
-          new Json.Of(
+          new JsonOf(
             MAPPER.createObjectNode()
           )
         ).leafAsBool("/nonexistent/path")
@@ -990,7 +990,7 @@ final class SmartJsonTest {
   void returnsFalseIfOptLeafInPathIsNotBool() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(
@@ -1007,7 +1007,7 @@ final class SmartJsonTest {
   void returnsFalseIfLeafInPathIsNotBool() {
     assertFalse(
       new SmartJson(
-        new Json.Of(
+        new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
             .<ObjectNode>set(


### PR DESCRIPTION
closes #27

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces the `Json.Of` class with the `JsonOf` decorator. It also replaces all references to `Json.Of` with `JsonOf`, and updates the affected tests.

### Detailed summary
- Replaces `Json.Of` with `JsonOf` decorator
- Updates all references to `Json.Of` with `JsonOf`
- Updates affected tests

> The following files were skipped due to too many changes: `src/test/java/io/github/eocqrs/eokson/SmartJsonTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->