### PR TITLE
SmartJson now is Jocument

### DIFF
--- a/src/main/java/io/github/eocqrs/eokson/Jocument.java
+++ b/src/main/java/io/github/eocqrs/eokson/Jocument.java
@@ -31,24 +31,29 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * A smart JSON. It can represent itself in other data types such as,
+ * JSON Document.
+ * <p>
+ * It can represent itself in other data types such as,
  * byte arrays, {@link String}s, {@link InputStream}s, and so forth. It can also
  * give its nested JSONs and leaves, tell if it is missing and do other useful
  * things. To use it, you need to wrap another {@link Json} in it, e.g.
  * <pre>
  * {@code
- * Json original = new Json.Of(...);
- * SmartJson smart = new SmartJson(original);
- * String textual = smart.textual();
- * InputStream stream = smart.inputStream();
- * SmartJson nested = smart.at("/path/to/nested/json");
+ * Json original = new JsonOf(...);
+ * Jocument document = new Jocument(original);
+ * String textual = document.textual();
+ * InputStream stream = document.inputStream();
+ * Jocument nested = document.at("/path/to/nested/json");
  * if (!nested.isMissing()) {
  *     Optional<String> value = nested.leaf("fieldName");
  * }
  * }
  * </pre>
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
  */
-public final class SmartJson implements Json {
+public final class Jocument implements Json {
 
   /**
    * Object Mapper.
@@ -72,26 +77,32 @@ public final class SmartJson implements Json {
   /**
    * Ctor.
    *
-   * @param origin Original JSON as basis to this {@code SmartJson}.
+   * @param orgn Original JSON
    */
-  public SmartJson(final Json origin) {
+  public Jocument(final Json orgn) {
     this(
-      origin,
+      orgn,
       new Unchecked<>(
-        () -> MAPPER.readValue(origin.bytes(), ObjectNode.class)
+        () -> MAPPER.readValue(orgn.bytes(), ObjectNode.class)
       )
     );
   }
 
-  private SmartJson(final Json origin, final Unchecked<ObjectNode> jackson) {
-    this.origin = origin;
-    this.jackson = jackson;
+  /**
+   * Ctor.
+   *
+   * @param orgn Original JSON
+   * @param node Object node
+   */
+  private Jocument(final Json orgn, final Unchecked<ObjectNode> node) {
+    this.origin = orgn;
+    this.jackson = node;
   }
 
   /**
-   * Represent this JSON in textual form.
+   * JSON as text.
    *
-   * @return String representing this JSON in textual form.
+   * @return String representing this JSON in textual form
    */
   public String textual() {
     return new Unchecked<>(
@@ -100,9 +111,9 @@ public final class SmartJson implements Json {
   }
 
   /**
-   * Represent this JSON in pretty format textual form.
+   * JSON as pretty text.
    *
-   * @return String representing this JSON in pretty format textual form.
+   * @return String representing this JSON in pretty format textual form
    */
   public String pretty() {
     return new Unchecked<>(
@@ -112,32 +123,30 @@ public final class SmartJson implements Json {
   }
 
   /**
-   * Represent this JSON in an array of bytes.
+   * JSON as an array of bytes.
    *
-   * @return Byte array representing this JSON.
+   * @return Byte array
    */
   public byte[] byteArray() {
     return new ByteArray(this.bytes()).value();
   }
 
   /**
-   * Method to get a {@code String} type  leaf (primitive field) of this JSON.
+   * Get a leaf of type {@code String}, boxed in {@code Optional} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return Optional value of the leaf.
+   * @param path JSON path
+   * @return Optional leaf value
    */
   public Optional<String> optLeaf(final String path) {
     return this.nodeAt(path).map(JsonNode::textValue);
   }
 
   /**
-   * Method to get a {@code String} type leaf (primitive field) of this JSON.
+   * Get a leaf of type {@code String} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return String value of the field, if the leaf exists.
-   * @throws IllegalArgumentException if leaf does not exist.
+   * @param path JSON path
+   * @return String leaf value, if the leaf exists
+   * @throws IllegalArgumentException if leaf does not exist
    */
   public String leaf(final String path) {
     return this.optLeaf(path).orElseThrow(
@@ -148,23 +157,21 @@ public final class SmartJson implements Json {
   }
 
   /**
-   * Method to get an {@code int} type  leaf (primitive field) of this JSON.
+   * Get a leaf of type {@code Integer}, boxed in {@code Optional} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return Optional value of the leaf.
+   * @param path JSON path
+   * @return Optional leaf value
    */
   public Optional<Integer> optLeafAsInt(final String path) {
     return this.nodeAt(path).map(JsonNode::intValue);
   }
 
   /**
-   * Method to get an {@code int} type  leaf (primitive field) of this JSON.
+   * Get a leaf of type {@code int} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return Int value of the leaf.
-   * @throws IllegalArgumentException if leaf does not exist.
+   * @param path JSON path
+   * @return Int leaf value
+   * @throws IllegalArgumentException if leaf does not exist
    */
   public int leafAsInt(final String path) {
     return this.optLeafAsInt(path).orElseThrow(
@@ -175,23 +182,21 @@ public final class SmartJson implements Json {
   }
 
   /**
-   * Method to get a {@code double} type  leaf (primitive field) of this JSON.
+   * Get a leaf of type {@code double}, boxed in {@code Optional} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return Optional value of the leaf.
+   * @param path JSON path
+   * @return Optional leaf value
    */
   public Optional<Double> optLeafAsDouble(final String path) {
     return this.nodeAt(path).map(JsonNode::doubleValue);
   }
 
   /**
-   * Method to get an {@code double} type leaf (primitive field) of this JSON.
+   * Get a leaf of type {@code double} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return Double value of the leaf.
-   * @throws IllegalArgumentException if leaf does not exist.
+   * @param path JSON path
+   * @return Double leaf value
+   * @throws IllegalArgumentException if leaf does not exist
    */
   public double leafAsDouble(final String path) {
     return this.optLeafAsDouble(path).orElseThrow(
@@ -202,25 +207,21 @@ public final class SmartJson implements Json {
   }
 
   /**
-   * Method to get a {@code boolean} type  leaf (primitive field) of this
-   * JSON.
+   * Get a leaf of type {@code Boolean}, boxed in {@code Optional} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return Optional value of the leaf.
+   * @param path JSON path
+   * @return Optional leaf value
    */
   public Optional<Boolean> optLeafAsBool(final String path) {
     return this.nodeAt(path).map(JsonNode::booleanValue);
   }
 
   /**
-   * Method to get an {@code int} type field  leaf (primitive field) of this
-   * JSON.
+   * Get a leaf of type {@code boolean} of this JSON.
    *
-   * @param path JSON path to the leaf or the name of the leaf if it is
-   *             directly at the root of this JSON.
-   * @return Boolean value of the leaf.
-   * @throws IllegalArgumentException if field does not exist.
+   * @param path JSON path
+   * @return Boolean leaf value
+   * @throws IllegalArgumentException if field does not exist
    */
   public boolean leafAsBool(final String path) {
     return this.optLeafAsBool(path).orElseThrow(
@@ -231,49 +232,56 @@ public final class SmartJson implements Json {
   }
 
   private Optional<JsonNode> nodeAt(final String path) {
-    final JsonNode node = !path.isEmpty() && path.charAt(0) == '/'
-      ? this.jackson.value().at(path)
-      : this.jackson.value().path(path);
-    return node.isMissingNode()
-      ? Optional.empty()
-      : Optional.of(node);
+    final JsonNode node;
+    if (!path.isEmpty() && path.charAt(0) == '/') {
+      node = this.jackson.value().at(path);
+    } else {
+      node = this.jackson.value().path(path);
+    }
+    if (node.isMissingNode()) {
+      return Optional.empty();
+    }
+    return Optional.of(node);
   }
 
   /**
    * Represent this JSON as {@link ObjectNode} in case full JSON manipulation
    * capabilities offered by jackson-databind library are needed.
    *
-   * @return This JSON as {@link ObjectNode}.
+   * @return This JSON as {@link ObjectNode}
    */
   public ObjectNode objectNode() {
     return this.jackson.value();
   }
 
   /**
-   * Method to get a JSON nested within this JSON, specified by path. Path
-   * starts with a forward slash, and path elements are separated by forward
-   * slashes also, e.g.
+   * Get a JSON nested within this JSON, specified by path.
+   * Path starts with a forward slash, and path elements
+   * are separated by forward slashes also, e.g.
    * <pre>
    * {@code
-   * SmartJson nested = json.at("/path/to/nested/json");}
+   * Jocument nested = json.at("/path/to/nested/json");}
    * </pre>
    * This method never returns null. If there is no JSON as specified by the
    * path, a missing JSON is returned, i.e.
    * {@code returned.isMissing() == true}.
    *
-   * @param path Path to the nested JSON.
-   * @return The nested JSON, which could be missing.
+   * @param path Path to the nested JSON
+   * @return The nested JSON, which could be missing
    */
-  public SmartJson at(final String path) {
-    return new SmartJson(
-      new JsonOf(this.jackson.value().at(path))
+  public Jocument at(final String path) {
+    return new Jocument(
+      new JsonOf(
+        this.jackson.value()
+          .at(path)
+      )
     );
   }
 
   /**
-   * Method which tells if this JSON is missing.
+   * Tells if this JSON is missing.
    *
-   * @return true if this JSON is missing; otherwise false.
+   * @return Is missing or not
    */
   public boolean isMissing() {
     final byte[] bytes = this.byteArray();
@@ -287,6 +295,9 @@ public final class SmartJson implements Json {
 
   @Override
   public String toString() {
-    return new String(new ByteArray(this).value());
+    return new String(
+      new ByteArray(this)
+        .value()
+    );
   }
 }

--- a/src/main/java/io/github/eocqrs/eokson/Jocument.java
+++ b/src/main/java/io/github/eocqrs/eokson/Jocument.java
@@ -138,7 +138,10 @@ public final class Jocument implements Json {
    * @return Optional leaf value
    */
   public Optional<String> optLeaf(final String path) {
-    return this.nodeAt(path).map(JsonNode::textValue);
+    return new NodeAt(
+      path,
+      this.jackson
+    ).value().map(JsonNode::textValue);
   }
 
   /**
@@ -163,7 +166,10 @@ public final class Jocument implements Json {
    * @return Optional leaf value
    */
   public Optional<Integer> optLeafAsInt(final String path) {
-    return this.nodeAt(path).map(JsonNode::intValue);
+    return new NodeAt(
+      path,
+      this.jackson
+    ).value().map(JsonNode::intValue);
   }
 
   /**
@@ -188,7 +194,10 @@ public final class Jocument implements Json {
    * @return Optional leaf value
    */
   public Optional<Double> optLeafAsDouble(final String path) {
-    return this.nodeAt(path).map(JsonNode::doubleValue);
+    return new NodeAt(
+      path,
+      this.jackson
+    ).value().map(JsonNode::doubleValue);
   }
 
   /**
@@ -213,7 +222,10 @@ public final class Jocument implements Json {
    * @return Optional leaf value
    */
   public Optional<Boolean> optLeafAsBool(final String path) {
-    return this.nodeAt(path).map(JsonNode::booleanValue);
+    return new NodeAt(
+      path,
+      this.jackson
+    ).value().map(JsonNode::booleanValue);
   }
 
   /**
@@ -229,19 +241,6 @@ public final class Jocument implements Json {
         "No such field of specified type: " + path
       )
     );
-  }
-
-  private Optional<JsonNode> nodeAt(final String path) {
-    final JsonNode node;
-    if (!path.isEmpty() && path.charAt(0) == '/') {
-      node = this.jackson.value().at(path);
-    } else {
-      node = this.jackson.value().path(path);
-    }
-    if (node.isMissingNode()) {
-      return Optional.empty();
-    }
-    return Optional.of(node);
   }
 
   /**

--- a/src/main/java/io/github/eocqrs/eokson/MutableJson.java
+++ b/src/main/java/io/github/eocqrs/eokson/MutableJson.java
@@ -137,7 +137,7 @@ public final class MutableJson implements Json {
    * @return This JSON.
    */
   public MutableJson with(final String name, final Json value) {
-    this.base.set(name, new SmartJson(value).objectNode());
+    this.base.set(name, new Jocument(value).objectNode());
     return this;
   }
 

--- a/src/main/java/io/github/eocqrs/eokson/NodeAt.java
+++ b/src/main/java/io/github/eocqrs/eokson/NodeAt.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.eokson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Optional;
+
+/**
+ * Evaluate JSON Node at a given path.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.1.2
+ */
+public final class NodeAt implements Scalar<Optional<JsonNode>> {
+
+  /**
+   * JSON path.
+   */
+  private final String path;
+  /**
+   * Jackson Node.
+   */
+  private final Unchecked<ObjectNode> jackson;
+
+  /**
+   * Ctor.
+   *
+   * @param pth     Path
+   * @param jackson Jackson Node
+   */
+  public NodeAt(
+    final String pth,
+    final Unchecked<ObjectNode> jackson
+  ) {
+    this.path = pth;
+    this.jackson = jackson;
+  }
+
+  @Override
+  public Optional<JsonNode> value() {
+    final JsonNode node;
+    if (!this.path.isEmpty() && this.path.charAt(0) == '/') {
+      node = this.jackson.value().at(this.path);
+    } else {
+      node = this.jackson.value().path(this.path);
+    }
+    if (node.isMissingNode()) {
+      return Optional.empty();
+    }
+    return Optional.of(node);
+  }
+}

--- a/src/main/java/io/github/eocqrs/eokson/Scalar.java
+++ b/src/main/java/io/github/eocqrs/eokson/Scalar.java
@@ -25,6 +25,7 @@ package io.github.eocqrs.eokson;
 /**
  * Exception-Safe Scalar type.
  *
+ * @param <T> Scalar type
  * @author Aliaksei Bialiauski (abialaiuski.dev@gmail.com)
  * @since 0.1.2
  */

--- a/src/main/java/io/github/eocqrs/eokson/Scalar.java
+++ b/src/main/java/io/github/eocqrs/eokson/Scalar.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.eokson;
+
+/**
+ * Exception-Safe Scalar type.
+ *
+ * @author Aliaksei Bialiauski (abialaiuski.dev@gmail.com)
+ * @since 0.1.2
+ */
+interface Scalar<T> {
+
+  T value();
+}

--- a/src/test/java/io/github/eocqrs/eokson/ByteArrayTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/ByteArrayTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link ByteArray}.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.3.5
+ * @since 0.1.1
  */
 final class ByteArrayTest {
 
@@ -19,7 +19,7 @@ final class ByteArrayTest {
     MatcherAssert.assertThat(
       "Bytes in right format",
       new ByteArray(
-        new SmartJson(
+        new Jocument(
           new JsonOf(bytes)
         )
       ).value(),

--- a/src/test/java/io/github/eocqrs/eokson/EmptyTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/EmptyTest.java
@@ -26,6 +26,12 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Test case for {@link Empty}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
 final class EmptyTest {
 
   @Test

--- a/src/test/java/io/github/eocqrs/eokson/JocumentTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/JocumentTest.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-final class SmartJsonTest {
+/**
+ * Test case for {@link Jocument}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
+final class JocumentTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -50,7 +55,7 @@ final class SmartJsonTest {
   @BeforeEach
   void setUp() throws URISyntaxException {
     this.deep = Paths.get(
-      SmartJsonTest.class.getClassLoader()
+      JocumentTest.class.getClassLoader()
         .getResource("deep.json")
         .toURI()
     );
@@ -60,7 +65,7 @@ final class SmartJsonTest {
   void readsAsTextInRightFormat() {
     MatcherAssert.assertThat(
       "JSON as text in right format",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -78,7 +83,7 @@ final class SmartJsonTest {
   void readsAsPrettyInRightFormat() {
     MatcherAssert.assertThat(
       "JSON as pretty text in right format",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -103,7 +108,7 @@ final class SmartJsonTest {
     );
     MatcherAssert.assertThat(
       "Reads byte array",
-      new SmartJson(
+      new Jocument(
         new JsonOf(bytes)
       ).byteArray(),
       Matchers.equalTo(
@@ -119,7 +124,7 @@ final class SmartJsonTest {
       .put("field2", "value2");
     MatcherAssert.assertThat(
       "Reads Object Node",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           node
         )
@@ -132,7 +137,7 @@ final class SmartJsonTest {
   void readsAsLeaf() {
     MatcherAssert.assertThat(
       "Reads as JSON leaf",
-      new SmartJson(
+      new Jocument(
         new JsonOf(this.deep)
       ).at("/ocean/rock1/nereid2").leaf("hair"),
       Matchers.equalTo("red")
@@ -143,7 +148,7 @@ final class SmartJsonTest {
   void handlesMissingDataAtLeaf() {
     MatcherAssert.assertThat(
       "Handles missing data at leaf",
-      new SmartJson(
+      new Jocument(
         new JsonOf(this.deep)
       ).at("/ocean/nothing")
         .isMissing(),
@@ -155,7 +160,7 @@ final class SmartJsonTest {
   void readsLeafInArray() {
     MatcherAssert.assertThat(
       "Leaf in array in right format",
-      new SmartJson(
+      new Jocument(
         new JsonOf(this.deep)
       ).at("/ocean/rock1/nereid1/associates/0")
         .leaf("name"),
@@ -167,7 +172,7 @@ final class SmartJsonTest {
   void readsArraysInRightFormat() {
     MatcherAssert.assertThat(
       "JSON in right format",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           this.deep
         )
@@ -185,7 +190,7 @@ final class SmartJsonTest {
     final String array = "[{\"name\":\"Jason\"},{\"name\":\"Thetis\"}]";
     assertEquals(
       "Jason",
-      new SmartJson(
+      new Jocument(
         new JsonOf(this.deep)
       ).at("/ocean/rock1/nereid1/associates").at("/0").leaf("name")
     );
@@ -195,7 +200,7 @@ final class SmartJsonTest {
   void knowsIfMissing() {
     MatcherAssert.assertThat(
       "Missing in right format",
-      new SmartJson(new Missing()).isMissing(),
+      new Jocument(new Missing()).isMissing(),
       Matchers.equalTo(true)
     );
   }
@@ -204,7 +209,7 @@ final class SmartJsonTest {
   void knowsEmptyJsonIsNotMissing() {
     MatcherAssert.assertThat(
       "Empty JSON is not missing",
-      new SmartJson(
+      new Jocument(
         new JsonOf("{}")
       ).isMissing(),
       Matchers.equalTo(false)
@@ -216,7 +221,7 @@ final class SmartJsonTest {
     final String data = "test";
     MatcherAssert.assertThat(
       "Stringifies in right format",
-      new SmartJson(
+      new Jocument(
         new JsonOf(data)
       ).toString(),
       Matchers.equalTo(data)
@@ -225,7 +230,7 @@ final class SmartJsonTest {
 
   @Test
   void readsTwice() {
-    final SmartJson json = new SmartJson(
+    final Jocument json = new Jocument(
       new JsonOf("{\"field1\":\"value1\",\"field2\":\"value2\"}")
     );
     MatcherAssert.assertThat(
@@ -244,7 +249,7 @@ final class SmartJsonTest {
   void findsOptLeaf() {
     assertEquals(
       "value2",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -258,7 +263,7 @@ final class SmartJsonTest {
   void leafsInRightFormat() {
     MatcherAssert.assertThat(
       "Leafs in right format",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -273,7 +278,7 @@ final class SmartJsonTest {
   void returnsEmptyOnEmptyLeaf() {
     MatcherAssert.assertThat(
       "Returns False on empty leaf",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -288,7 +293,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -302,7 +307,7 @@ final class SmartJsonTest {
     final String field = "intField";
     MatcherAssert.assertThat(
       "Returns empty on leaf is not string",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -319,7 +324,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
               .put("field1", "value1")
@@ -334,7 +339,7 @@ final class SmartJsonTest {
   void returnsEmptyOnEmptyString() {
     MatcherAssert.assertThat(
       "Returns empty on empty string",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -349,7 +354,7 @@ final class SmartJsonTest {
   void findsOptLeafInPath() {
     assertEquals(
       "innerValue",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -367,7 +372,7 @@ final class SmartJsonTest {
   void findsLeafInPath() {
     assertEquals(
       "innerValue",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -384,7 +389,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalForNonexistentLeafInPath() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -397,7 +402,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -409,7 +414,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalIfLeafInPathIsNotString() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -428,7 +433,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
               .put("field1", "value1")
@@ -447,7 +452,7 @@ final class SmartJsonTest {
   void findsOptLeafAsInt() {
     assertEquals(
       14,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -461,7 +466,7 @@ final class SmartJsonTest {
   void findsLeafAsInt() {
     assertEquals(
       14,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -474,7 +479,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalForNonexistentIntLeaf() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -487,7 +492,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -500,7 +505,7 @@ final class SmartJsonTest {
   void returnsZeroIfOptLeafIsNotInt() {
     assertEquals(
       0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -514,7 +519,7 @@ final class SmartJsonTest {
   void returnsZeroIfLeafIsNotInt() {
     assertEquals(
       0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -528,7 +533,7 @@ final class SmartJsonTest {
   void returnsIntEvenIfOptLeafIsDouble() {
     assertEquals(
       5,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -542,7 +547,7 @@ final class SmartJsonTest {
   void returnsIntEvenIfLeafIsDouble() {
     assertEquals(
       5,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -556,7 +561,7 @@ final class SmartJsonTest {
   void findsOptIntLeafInPath() {
     assertEquals(
       999,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -574,7 +579,7 @@ final class SmartJsonTest {
   void findsLeafIntInPath() {
     assertEquals(
       12,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -591,7 +596,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalForNonexistentLeafIntInPath() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -604,7 +609,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -617,7 +622,7 @@ final class SmartJsonTest {
   void returnsZeroIfOptLeafInPathIsNotInt() {
     assertEquals(
       0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -635,7 +640,7 @@ final class SmartJsonTest {
   void returnsZeroIfLeafInPathIsNotInt() {
     assertEquals(
       0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -653,7 +658,7 @@ final class SmartJsonTest {
   void returnsIntEvenIfOptLeafInPathIsDouble() {
     assertEquals(
       5,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -671,7 +676,7 @@ final class SmartJsonTest {
   void findsOptLeafAsDouble() {
     assertEquals(
       14.9,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", 14.9)
@@ -685,7 +690,7 @@ final class SmartJsonTest {
   void findsLeafAsDouble() {
     assertEquals(
       14.9,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", 14.9)
@@ -698,7 +703,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalForNonexistentDoubleLeaf() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -711,7 +716,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -724,7 +729,7 @@ final class SmartJsonTest {
   void returnsZeroIfOptLeafIsNotDouble() {
     assertEquals(
       0.0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -738,7 +743,7 @@ final class SmartJsonTest {
   void returnsZeroIfLeafIsNotDouble() {
     assertEquals(
       0.0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -752,7 +757,7 @@ final class SmartJsonTest {
   void returnsDoubleEvenIfOptLeafIsInt() {
     assertEquals(
       5.0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -766,7 +771,7 @@ final class SmartJsonTest {
   void returnsDoubleEvenIfLeafIsInt() {
     assertEquals(
       5.0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -780,7 +785,7 @@ final class SmartJsonTest {
   void findsOptDoubleLeafInPath() {
     assertEquals(
       999.17,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -798,7 +803,7 @@ final class SmartJsonTest {
   void findsLeafDoubleInPath() {
     assertEquals(
       12.45,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -815,7 +820,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalForNonexistentLeafDoubleInPath() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -828,7 +833,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -841,7 +846,7 @@ final class SmartJsonTest {
   void returnsZeroIfOptLeafInPathIsNotDouble() {
     assertEquals(
       0.0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -859,7 +864,7 @@ final class SmartJsonTest {
   void returnsZeroIfLeafInPathIsNotDouble() {
     assertEquals(
       0.0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -877,7 +882,7 @@ final class SmartJsonTest {
   void returnsDoubleEvenIfOptLeafInPathIsInt() {
     assertEquals(
       5.0,
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -894,7 +899,7 @@ final class SmartJsonTest {
   @Test
   void findsOptLeafAsBool() {
     assertTrue(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -907,7 +912,7 @@ final class SmartJsonTest {
   @Test
   void findsLeafAsBool() {
     assertTrue(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -920,7 +925,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalForNonexistentBooleanLeaf() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -933,7 +938,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -945,7 +950,7 @@ final class SmartJsonTest {
   @Test
   void returnsFalseIfOptLeafIsNotBool() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -958,7 +963,7 @@ final class SmartJsonTest {
   @Test
   void returnsFalseIfLeafIsNotBool() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("stringField", "value1")
@@ -971,7 +976,7 @@ final class SmartJsonTest {
   @Test
   void findsOptBoolLeafInPath() {
     assertTrue(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -988,7 +993,7 @@ final class SmartJsonTest {
   @Test
   void findsLeafBoolInPath() {
     assertTrue(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -1005,7 +1010,7 @@ final class SmartJsonTest {
   @Test
   void returnsEmptyOptionalForNonexistentLeafBoolInPath() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
         )
@@ -1018,7 +1023,7 @@ final class SmartJsonTest {
     assertTrue(
       assertThrows(
         IllegalArgumentException.class,
-        () -> new SmartJson(
+        () -> new Jocument(
           new JsonOf(
             MAPPER.createObjectNode()
           )
@@ -1030,7 +1035,7 @@ final class SmartJsonTest {
   @Test
   void returnsFalseIfOptLeafInPathIsNotBool() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")
@@ -1047,7 +1052,7 @@ final class SmartJsonTest {
   @Test
   void returnsFalseIfLeafInPathIsNotBool() {
     assertFalse(
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           MAPPER.createObjectNode()
             .put("field1", "value1")

--- a/src/test/java/io/github/eocqrs/eokson/JsonEnvelopeTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/JsonEnvelopeTest.java
@@ -27,6 +27,12 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Test case for {@link JsonEnvelope}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
 final class JsonEnvelopeTest {
 
   @Test

--- a/src/test/java/io/github/eocqrs/eokson/JsonOfTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/JsonOfTest.java
@@ -39,6 +39,12 @@ import java.nio.file.Paths;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * Test case for {@link JsonOf}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.1.1
+ */
 final class JsonOfTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/test/java/io/github/eocqrs/eokson/MissingTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/MissingTest.java
@@ -27,6 +27,12 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Test case for {@link Missing}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
 final class MissingTest {
     @Test
     void creates() throws IOException {

--- a/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
@@ -30,6 +30,12 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
+/**
+ * Test case for {@link MutableJson}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
 final class MutableJsonTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -76,7 +82,7 @@ final class MutableJsonTest {
   void readJsonFromFileInRightFormat() throws URISyntaxException {
     MatcherAssert.assertThat(
       "JSON from file in right format",
-      new SmartJson(
+      new Jocument(
         new JsonOf(
           Paths.get(
             MutableJsonTest.class.getClassLoader().getResource(
@@ -86,7 +92,7 @@ final class MutableJsonTest {
         )
       ).pretty(),
       Matchers.equalTo(
-        new SmartJson(
+        new Jocument(
           new MutableJson().with(
             "ocean",
             new MutableJson().with(

--- a/src/test/java/io/github/eocqrs/eokson/NodeAtTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/NodeAtTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.eokson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link NodeAt}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.1.2
+ */
+final class NodeAtTest {
+
+  @Test
+  void readsNodeInRightFormat() {
+    final String value = "John";
+    MatcherAssert.assertThat(
+      "Node in right format",
+      new NodeAt(
+        "/name",
+        new Unchecked<>(
+          () -> new ObjectMapper()
+            .createObjectNode()
+            .put("name", value)
+        )
+      ).value().get().textValue(),
+      Matchers.equalTo(value)
+    );
+  }
+
+  @Test
+  void checksNodeIsPresent() {
+    MatcherAssert.assertThat(
+      "Node is present",
+      new NodeAt(
+        "/exists",
+        new Unchecked<>(
+          () -> new ObjectMapper()
+            .createObjectNode()
+            .put("exists", "some-value")
+        )
+      ).value().isPresent(),
+      Matchers.equalTo(true)
+    );
+  }
+
+  @Test
+  void checksNodeIsNotPresent() {
+    MatcherAssert.assertThat(
+      "Node is not present",
+      new NodeAt(
+        "/notexists",
+        new Unchecked<>(
+          () -> new ObjectMapper()
+            .createObjectNode()
+            .put("exists", "some-value")
+        )
+      ).value().isPresent(),
+      Matchers.equalTo(false)
+    );
+  }
+}


### PR DESCRIPTION
closes #34

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds author information and version numbers to test cases, updates class names, and introduces new classes for JSON manipulation. 

### Detailed summary
- Adds author information and version numbers to test cases
- Renames `SmartJson` to `Jocument`
- Introduces `JsonOf`, `MutableJson`, `JsonEnvelope`, `Missing`, `NodeAt`, and `Scalar` classes
- Updates `MutableJson` to use `Jocument` instead of `SmartJson`
- Adds copyright notices and licensing information to new classes

> The following files were skipped due to too many changes: `src/main/java/io/github/eocqrs/eokson/SmartJson.java`, `src/test/java/io/github/eocqrs/eokson/SmartJsonTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->