### PR TITLE
MissingTest assertions, indentation

### DIFF
--- a/src/test/java/io/github/eocqrs/eokson/MissingTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/MissingTest.java
@@ -22,10 +22,13 @@
 
 package io.github.eocqrs.eokson;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test case for {@link Missing}.
@@ -34,11 +37,13 @@ import org.junit.jupiter.api.Test;
  * @since 0.0.0
  */
 final class MissingTest {
-    @Test
-    void creates() throws IOException {
-        assertEquals(
-            0,
-            new Missing().bytes().available()
-        );
-    }
+
+  @Test
+  void readsAvailableBytes() throws IOException {
+    MatcherAssert.assertThat(
+      "Zero bytes available",
+      new Missing().bytes().available(),
+      new IsEqual<>(0)
+    );
+  }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the test case for the `Missing` class.

### Detailed summary:
- Updated the test case method name from `creates` to `readsAvailableBytes`.
- Updated the assertion statement to use `MatcherAssert.assertThat` instead of `assertEquals`.
- Added a descriptive message to the assertion to clarify the expected result.
- Reordered the import statements.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->