### PR TITLE
with json array

### DIFF
--- a/src/main/java/io/github/eocqrs/eokson/MutableJson.java
+++ b/src/main/java/io/github/eocqrs/eokson/MutableJson.java
@@ -23,9 +23,12 @@
 package io.github.eocqrs.eokson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.InputStream;
+import java.util.Collection;
+import java.util.function.Consumer;
 
 /**
  * JSON, which is mutable and can be used to build custom JSONs, e.g.
@@ -138,6 +141,26 @@ public final class MutableJson implements Json {
    */
   public MutableJson with(final String name, final Json value) {
     this.base.set(name, new Jocument(value).objectNode());
+    return this;
+  }
+
+  /**
+   * Add a JSON Array into the current JSON.
+   *
+   * @param name  Name of the field.
+   * @param jsons JSON array.
+   * @return This JSON.
+   */
+  public MutableJson with(
+    final String name,
+    final Collection<MutableJson> jsons
+  ) {
+    final ArrayNode node = MAPPER.createArrayNode();
+    this.base.set(name, node);
+    jsons.forEach(
+      json ->
+        node.add(new Jocument(json).objectNode())
+    );
     return this;
   }
 

--- a/src/main/java/io/github/eocqrs/eokson/MutableJson.java
+++ b/src/main/java/io/github/eocqrs/eokson/MutableJson.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.function.Consumer;
 
 /**
  * JSON, which is mutable and can be used to build custom JSONs, e.g.

--- a/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
@@ -25,10 +25,12 @@ package io.github.eocqrs.eokson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * Test case for {@link MutableJson}.
@@ -152,6 +154,45 @@ final class MutableJsonTest {
       "Empty JSON in right format",
       new MutableJson().toString(),
       Matchers.equalTo("{}")
+    );
+  }
+
+  @Test
+  void createsBooks() throws URISyntaxException {
+    MatcherAssert.assertThat(
+      "JSON in right format",
+      new Jocument(
+        new MutableJson()
+          .with(
+            "amazon", new MutableJson()
+              .with(
+                "shop",
+                new MutableJson()
+                  .with(
+                    "books",
+                    List.of(
+                      new MutableJson()
+                        .with("name", "Code Complete")
+                        .with("price", 30),
+                      new MutableJson()
+                        .with("name", "PMP exam prep.")
+                        .with("price", 60)
+                    )
+                  )
+              )
+          )
+      ).pretty(),
+      new IsEqual<>(
+        new Jocument(
+          new JsonOf(
+            Paths.get(
+              JocumentTest.class.getClassLoader()
+                .getResource("amazon.json")
+                .toURI()
+            )
+          )
+        ).pretty()
+      )
     );
   }
 }


### PR DESCRIPTION
closes #20

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new method `with` to `MutableJson` class to add a JSON array into the current JSON.
- The `with` method takes a name and a collection of `MutableJson` objects as parameters.
- The method creates an `ArrayNode` and adds each `MutableJson` object as an `ObjectNode` to the array.
- The array is then added to the current JSON with the specified name.
- Added a test case in `MutableJsonTest` to verify the functionality of the new `with` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->