### PR TITLE
enable jtcop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,19 +221,18 @@ SOFTWARE.
           <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
-      <!--      @todo #6:45m/DEV enable jtcop-->
-      <!--      <plugin>-->
-      <!--        <groupId>com.github.volodya-lombrozo</groupId>-->
-      <!--        <artifactId>jtcop-maven-plugin</artifactId>-->
-      <!--        <version>${jtcop.version}</version>-->
-      <!--        <executions>-->
-      <!--          <execution>-->
-      <!--            <goals>-->
-      <!--              <goal>check</goal>-->
-      <!--            </goals>-->
-      <!--          </execution>-->
-      <!--        </executions>-->
-      <!--      </plugin>-->
+      <plugin>
+        <groupId>com.github.volodya-lombrozo</groupId>
+        <artifactId>jtcop-maven-plugin</artifactId>
+        <version>${jtcop.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <!--      @todo #6:20m/DEV enable sa-tan-->
       <!--      <plugin>-->
       <!--        <groupId>ru.l3r8y</groupId>-->

--- a/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/MutableJsonTest.java
@@ -81,7 +81,7 @@ final class MutableJsonTest {
   }
 
   @Test
-  void readJsonFromFileInRightFormat() throws URISyntaxException {
+  void readsJsonFromFileInRightFormat() throws URISyntaxException {
     MatcherAssert.assertThat(
       "JSON from file in right format",
       new Jocument(


### PR DESCRIPTION
closes #9 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating a test method name and adding a Maven plugin. 

### Detailed summary
- Renamed the test method `readJsonFromFileInRightFormat` to `readsJsonFromFileInRightFormat`.
- Added the Maven plugin `jtcop-maven-plugin` to the `pom.xml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->