### PR TITLE
JsonXML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ SOFTWARE.
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jackson-databind.version>2.13.4.2</jackson-databind.version>
+    <jackson-databind.version>2.15.2</jackson-databind.version>
     <junit-jupiter-api.version>5.3.1</junit-jupiter-api.version>
     <junit-jupiter-engine.version>5.3.1</junit-jupiter-engine.version>
     <assert4j-core.version>3.24.2</assert4j-core.version>
@@ -91,6 +91,21 @@ SOFTWARE.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
       <version>${jackson-databind.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/io/github/eocqrs/eokson/JsonXML.java
+++ b/src/main/java/io/github/eocqrs/eokson/JsonXML.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.eokson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import org.cactoos.Text;
+
+/**
+ * JSON in XML.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.2
+ */
+public final class JsonXML implements Text {
+
+  /**
+   * Json.
+   */
+  private final Json json;
+  /**
+   * Root XML node.
+   */
+  private final String root;
+
+  /**
+   * Ctor.
+   *
+   * @param jsn JSON
+   * @param rt  Root XML node
+   */
+  public JsonXML(final Json jsn, final String rt) {
+    this.json = jsn;
+    this.root = rt;
+  }
+
+  @Override
+  public String asString() throws Exception {
+    final XmlMapper xml = new XmlMapper();
+    final ObjectMapper mapper = new ObjectMapper();
+    final JsonNode node = mapper.readTree(
+      new Jocument(
+        this.json
+      ).pretty()
+    );
+    xml.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+    return xml.writer()
+      .withRootName(this.root)
+      .writeValueAsString(node);
+  }
+}

--- a/src/main/java/io/github/eocqrs/eokson/WithDeclaration.java
+++ b/src/main/java/io/github/eocqrs/eokson/WithDeclaration.java
@@ -22,50 +22,21 @@
 
 package io.github.eocqrs.eokson;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.cactoos.Text;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 /**
- * JSON in XML.
+ * XML Mapper With Declaration.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.3.2
  */
-public final class JsonXML implements Text {
-
-  /**
-   * Json.
-   */
-  private final Json json;
-  /**
-   * Root XML node.
-   */
-  private final String root;
-
-  /**
-   * Ctor.
-   *
-   * @param jsn JSON
-   * @param rt  Root XML node
-   */
-  public JsonXML(final Json jsn, final String rt) {
-    this.json = jsn;
-    this.root = rt;
-  }
+final class WithDeclaration implements Scalar<XmlMapper> {
 
   @Override
-  public String asString() throws Exception {
-    final ObjectMapper mapper = new ObjectMapper();
-    final JsonNode node = mapper.readTree(
-      new Jocument(
-        this.json
-      ).pretty()
-    );
-    return new WithDeclaration()
-      .value()
-      .writer()
-      .withRootName(this.root)
-      .writeValueAsString(node);
+  public XmlMapper value() {
+    final XmlMapper xml = new XmlMapper();
+    xml.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+    return xml;
   }
 }

--- a/src/test/java/io/github/eocqrs/eokson/JsonXMLTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/JsonXMLTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.eokson;
+
+import org.cactoos.io.ResourceOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link JsonXML}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.2
+ */
+final class JsonXMLTest {
+
+  @Test
+  void readsXmlInRightFormat() throws Exception {
+    MatcherAssert.assertThat(
+      "XML in right format",
+      new JsonXML(
+        new JsonOf(
+          new ResourceOf("simple.json").stream()
+        ),
+        "test"
+      ).asString(),
+      new IsEqual<>(
+        "<?xml version='1.0' encoding='UTF-8'?>"
+          + "<test><test>true</test><simple>true</simple><project>eokson-0.3.2</project></test>"
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/eokson/WithDeclarationTest.java
+++ b/src/test/java/io/github/eocqrs/eokson/WithDeclarationTest.java
@@ -22,50 +22,26 @@
 
 package io.github.eocqrs.eokson;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.cactoos.Text;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 
 /**
- * JSON in XML.
+ * Test case for {@link WithDeclaration}.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.3.2
  */
-public final class JsonXML implements Text {
+final class WithDeclarationTest {
 
-  /**
-   * Json.
-   */
-  private final Json json;
-  /**
-   * Root XML node.
-   */
-  private final String root;
-
-  /**
-   * Ctor.
-   *
-   * @param jsn JSON
-   * @param rt  Root XML node
-   */
-  public JsonXML(final Json jsn, final String rt) {
-    this.json = jsn;
-    this.root = rt;
-  }
-
-  @Override
-  public String asString() throws Exception {
-    final ObjectMapper mapper = new ObjectMapper();
-    final JsonNode node = mapper.readTree(
-      new Jocument(
-        this.json
-      ).pretty()
+  @Test
+  void readsMapperInRightFormat() {
+    final XmlMapper mapper = new WithDeclaration().value();
+    MatcherAssert.assertThat(
+      "Mapper is present",
+      mapper,
+      Matchers.notNullValue()
     );
-    return new WithDeclaration()
-      .value()
-      .writer()
-      .withRootName(this.root)
-      .writeValueAsString(node);
   }
 }

--- a/src/test/resources/simple.json
+++ b/src/test/resources/simple.json
@@ -1,0 +1,5 @@
+{
+  "test": "true",
+  "simple": "true",
+  "project": "eokson-0.3.2"
+}


### PR DESCRIPTION
closes #49

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and adding XML support to the project. 

### Detailed summary
- Added XML support by introducing `JsonXML` class.
- Updated `pom.xml` to use the latest version of `jackson-databind` (2.15.2).
- Added new dependencies for XML support (`jackson-dataformat-xml`, `jackson-core`, `jackson-annotations`).
- Added `WithDeclaration` class for configuring XML mapper with XML declaration.
- Added corresponding test cases for `WithDeclaration` and `JsonXML` classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->